### PR TITLE
Add plain reserve (no timeout) command

### DIFF
--- a/tubeset.go
+++ b/tubeset.go
@@ -27,7 +27,12 @@ func NewTubeSet(c *Conn, name ...string) *TubeSet {
 // Typically, a client will reserve a job, perform some work, then delete
 // the job with Conn.Delete.
 func (t *TubeSet) Reserve(timeout time.Duration) (id uint64, body []byte, err error) {
-	r, err := t.Conn.cmd(nil, t, nil, "reserve-with-timeout", dur(timeout))
+	var r req
+	if timeout < 0 {
+		r, err = t.Conn.cmd(nil, t, nil, "reserve")
+	} else {
+		r, err = t.Conn.cmd(nil, t, nil, "reserve-with-timeout", dur(timeout))
+	}
 	if err != nil {
 		return 0, nil, err
 	}

--- a/tubeset.go
+++ b/tubeset.go
@@ -22,7 +22,8 @@ func NewTubeSet(c *Conn, name ...string) *TubeSet {
 
 // Reserve reserves and returns a job from one of the tubes in t. If no
 // job is available before time timeout has passed, Reserve returns a
-// ConnError recording ErrTimeout.
+// ConnError recording ErrTimeout. A time < 0 will block until a job is
+// returned.
 //
 // Typically, a client will reserve a job, perform some work, then delete
 // the job with Conn.Delete.


### PR DESCRIPTION
I'm not sure if overloading ``timeout`` is the best approach, but I couldn't think of non-obnoxious names to differentiate the methods (``BlockingReserve``? ``ReserveWithTimeout``? bleh)